### PR TITLE
Sort listdir

### DIFF
--- a/build-file.py
+++ b/build-file.py
@@ -11,7 +11,11 @@ if __name__ == "__main__":
     outFile = open(outFileName, 'w')
     directory = "output"
     frame = 0
-    for filename in os.listdir(directory):
+    
+    list_of_files = os.listdir(directory)
+    list_of_files.sort()
+
+    for filename in sorted(list_of_files):
         if filename.endswith(".png"): 
             path = os.path.join(directory, filename)
             img = Image.open(path)


### PR DESCRIPTION
Sorts the result of `listdir` which _may_ be randomized, depending on the OS. For example, I discovered a list of files of format `file-%03d.png` on macOS to be fairly randomized when using `listdir` directly.

[From the documentation (emphasis mine)](https://docs.python.org/3.6/library/os.html#os.listdir)
> **os.listdir(path='.')**
> Return a list containing the names of the entries in the directory given by path. **<ins>The list is in arbitrary order</ins>**, and does not include the special entries '.' and '..' even if they are present in the directory.